### PR TITLE
Adding new turn management, optional integration with advanced-encounter

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -1,0 +1,12 @@
+{
+  "enhancedcombathud-cosmere-rpg": {
+    "turn": {
+      "panel": "Turn",
+      "start": "Start Turn",
+      "startFast": "Start Fast Turn",
+      "startSlow": "Start Slow Turn",
+      "endFast": "End Fast Turn",
+      "endSlow": "End Slow Turn"
+    }
+  }
+}

--- a/module.json
+++ b/module.json
@@ -23,6 +23,16 @@
   "esmodules": [
     "scripts/main.js"
   ],
+  "styles": [
+    "styles/module.css"
+  ],
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "languages/en.json"
+    }
+  ],
   "relationships": {
     "systems": [
       {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,5 @@
 import CosmerePortrait from "./ui/portrait.js";
+import { CosmereTurnPanel } from "./ui/turn-panel/index.js";
 import CosmereSkillsDrawer from "./ui/drawer.js";
 import CosmereWeaponSets from "./ui/weapon-sets.js"
 import CosmereMovementHUD from "./ui/movement-hud.js";
@@ -29,7 +30,7 @@ Hooks.once("argonInit", (CoreHUD) => {
 
     const includePassTurn = game.settings.get(MODULE_ID, "includePassTurn"); //TODO: Make this a setting
     if(includePassTurn)
-        mainPanels.push(CoreHUD.ARGON.PREFAB.PassTurnPanel);
+        mainPanels.push(CosmereTurnPanel);
 
     CoreHUD.defineMainPanels(mainPanels);
     CoreHUD.defineWeaponSets(CosmereWeaponSets);
@@ -41,6 +42,12 @@ Hooks.once("argonInit", (CoreHUD) => {
 //Gotta make sure settings are registered before the argon stuff is invoked
 Hooks.once("init", registerSettings);
 Hooks.once("ready", setupUtilities);
+
+// Argon has no listener for updateCombatant (e.g. toggleTurnSpeed, markActivated).
+// Call updateVisibility on all combat panels so buttons re-render on combatant changes.
+Hooks.on("updateCombatant", () => {
+    ui.ARGON?.components?.combat?.forEach((p) => p.updateVisibility());
+});
 
 Hooks.on("renderSettingsConfig", (app, html, data) => {
     html = html instanceof jQuery ? html[0] : html;

--- a/scripts/ui/portrait.js
+++ b/scripts/ui/portrait.js
@@ -41,18 +41,6 @@ export default class CosmerePortrait extends ARGON.PORTRAIT.PortraitPanel {
     async _getButtons() {
         const buttons = [];
 
-        if(game.combat){
-            buttons.push({
-                id: "toggle-speed",
-                icon: "fas fa-stopwatch",
-                label: "Toggle Turn Speed",
-                onClick: (e) => {
-                    const combatant = game.combat.getCombatantsByActor(this.actor)[0];
-                    combatant?.toggleTurnSpeed();
-                },
-            });
-        }
-
         buttons.push({
             id: "open-sheet",
             icon: "fas fa-suitcase",

--- a/scripts/ui/turn-panel/advanced.js
+++ b/scripts/ui/turn-panel/advanced.js
@@ -1,0 +1,153 @@
+/**
+ * Advanced Encounters turn panel buttons.
+ *
+ * With AE active, a boss actor has two separate combatant entries (Fast + Slow).
+ * The factory iterates ALL combatants for the actor and produces a button group
+ * per entry, so each entry's buttons hold a direct, safe reference to their
+ * specific combatant document.
+ *
+ * For each combatant entry:
+ *   - ToggleTurnSpeedButton    – switches Fast ↔ Slow while not yet activated
+ *                                (skipped for boss entries — AE owns their speed)
+ *   - StartTurnAdvancedButton  – activates the combatant and sets it as current
+ *   - EndTurnAdvancedButton    – advances to the next turn, clearing the current combatant
+ */
+
+import { ToggleTurnSpeedButton } from "./toggle-speed-button.js";
+
+const END_TURN_ICON = "modules/enhancedcombathud/icons/duration.webp";
+
+// ---------------------------------------------------------------------------
+// Start turn
+// ---------------------------------------------------------------------------
+
+class StartTurnAdvancedButton extends CONFIG.ARGON.MAIN.BUTTONS.ActionButton {
+    constructor(combatant) {
+        super();
+        this._combatant = combatant;
+    }
+
+    get label() {
+        if (this._combatant.isBoss) {
+            return this._combatant.turnSpeed === "fast"
+                ? "enhancedcombathud-cosmere-rpg.turn.startFast"
+                : "enhancedcombathud-cosmere-rpg.turn.startSlow";
+        }
+        return "enhancedcombathud-cosmere-rpg.turn.start";
+    }
+
+    get icon() { return END_TURN_ICON; }
+
+    get colorScheme() { return 4; }
+
+    get visible() {
+        return (
+            !!game.combat?.started &&
+            !this._combatant.activated &&
+            game.combat.turn === null && // No other combatant currently playing their turn
+            this._allPreviousPhasesActivated(this._combatant)
+        );
+    }
+
+    /**
+     * Returns true when all combatants in phases that precede this combatant's
+     * phase have already activated (or the combatant is in phase 0).
+     *
+     * @param {Combatant} combatant
+     * @returns {boolean}
+     */
+    _allPreviousPhasesActivated(combatant) {
+        const myPhase = this._getTurnPhaseIndex(combatant);
+        if (myPhase === 0) return true;
+        return (game.combat?.turns ?? []).every(
+            (c) => this._getTurnPhaseIndex(c) >= myPhase || c.activated
+        );
+    }
+
+    /**
+     * Returns the phase index for a combatant in the Cosmere initiative order.
+     *
+     * Phase order:
+     *   0 – Fast Players
+     *   1 – Fast NPCs
+     *   2 – Slow Players
+     *   3 – Slow NPCs
+     *
+     * @param {Combatant} combatant
+     * @returns {number}
+     */
+    _getTurnPhaseIndex(combatant) {
+        const isCharacter = combatant.actor?.type === "character";
+        const isFast = combatant.turnSpeed === "fast";
+        if (isFast) 
+            return isCharacter ? 0 : 1;
+        else 
+            return isCharacter ? 2 : 3;
+    }
+
+    async _onLeftClick() {
+        await this._combatant.markActivated();
+        await game.combat.setCurrentTurnFromCombatant(this._combatant);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// End turn
+// ---------------------------------------------------------------------------
+
+class EndTurnAdvancedButton extends CONFIG.ARGON.MAIN.BUTTONS.ActionButton {
+    constructor(combatant) {
+        super();
+        this._combatant = combatant;
+    }
+
+    get label() {
+        if (this._combatant.isBoss) {
+            return this._combatant.turnSpeed === "fast"
+                ? "enhancedcombathud-cosmere-rpg.turn.endFast"
+                : "enhancedcombathud-cosmere-rpg.turn.endSlow";
+        }
+        return "enhancedcombathud.hud.endturn.name";
+    }
+
+    get icon() { return END_TURN_ICON; }
+
+    get colorScheme() { return 4; }
+
+    get visible() {
+        return game.combat?.combatant?.id === this._combatant.id;
+    }
+
+    async _onLeftClick() {
+        await game.combat?.nextTurn();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the button set for the Advanced Encounters turn panel.
+ *
+ * One button group (optional toggle + start + end) is created for every
+ * combatant entry belonging to this actor.  Boss entries never get a toggle
+ * button because AE controls their speed via separate Fast/Slow entries.
+ *
+ * @param {Actor} actor
+ * @returns {ActionButton[]}
+ */
+export function buildAdvancedButtons(actor) {
+    const combatants = game.combat?.getCombatantsByActor(actor) ?? [];
+    const buttons = [];
+
+    for (const combatant of combatants) {
+        if (!combatant.isBoss) {
+            buttons.push(new ToggleTurnSpeedButton(combatant));
+        }
+        buttons.push(new StartTurnAdvancedButton(combatant));
+        buttons.push(new EndTurnAdvancedButton(combatant));
+    }
+
+    return buttons;
+}

--- a/scripts/ui/turn-panel/basic.js
+++ b/scripts/ui/turn-panel/basic.js
@@ -1,0 +1,87 @@
+/**
+ * Basic (non–Advanced Encounters) turn panel buttons.
+ *
+ * For non-boss actors:
+ *   - ToggleTurnSpeedBasicButton  – switches Fast ↔ Slow while not yet activated
+ *   - EndTurnBasicButton          – marks the combatant as activated
+ *
+ * For boss actors (single combatant entry, two activation flags):
+ *   - BossSlowEndTurnBasicButton  – extends EndTurnBasicButton; marks slow turn done
+ *   - BossFastEndTurnBasicButton  – extends EndTurnBasicButton; marks fast turn done
+ */
+
+import { ToggleTurnSpeedButton } from "./toggle-speed-button.js";
+
+const END_TURN_ICON = "modules/enhancedcombathud/icons/duration.webp";
+
+// ---------------------------------------------------------------------------
+// End-turn base (shared icon, colorScheme, and combat-started guard)
+// ---------------------------------------------------------------------------
+
+class EndTurnBasicButton extends CONFIG.ARGON.MAIN.BUTTONS.ActionButton {
+    constructor(combatant) {
+        super();
+        this._combatant = combatant;
+    }
+
+    get label() { return "enhancedcombathud.hud.endturn.name"; }
+
+    get icon() { return END_TURN_ICON; }
+
+    get colorScheme() { return 4; }
+
+    get visible() {
+        return !!game.combat?.started && !this._combatant.activated;
+    }
+
+    async _onLeftClick() {
+        await this._combatant.markActivated();
+    }
+
+    get template() {
+        // Required due to template being by default computed from the immediate parent class name
+        return "modules/enhancedcombathud/templates/partials/ActionButton.hbs";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boss helpers – extend the base, override only what differs
+// ---------------------------------------------------------------------------
+class BossFastEndTurnBasicButton extends EndTurnBasicButton {
+    get label() { return "enhancedcombathud-cosmere-rpg.turn.endFast"; }
+    get visible() { return !!game.combat?.started && !this._combatant.bossFastActivated; }
+    async _onLeftClick() { await this._combatant.markActivated(true); }
+}
+
+class BossSlowEndTurnBasicButton extends EndTurnBasicButton {
+    get label() { return "enhancedcombathud-cosmere-rpg.turn.endSlow"; }
+    // visible: same as base – hidden once .activated is set
+    async _onLeftClick() { await this._combatant.markActivated(false); }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the button set for the basic (non-AE) turn panel.
+ *
+ * @param {Actor} actor
+ * @returns {ActionButton[]}
+ */
+export function buildBasicButtons(actor) {
+    const combatant = game.combat?.getCombatantsByActor(actor)?.[0];
+    if (!combatant) return [];
+
+    if (combatant.isBoss) {
+        return [
+            new BossFastEndTurnBasicButton(combatant),
+            new BossSlowEndTurnBasicButton(combatant),
+        ];
+    }
+
+    return [
+        new ToggleTurnSpeedButton(combatant),
+        new EndTurnBasicButton(combatant),
+    ];
+}

--- a/scripts/ui/turn-panel/index.js
+++ b/scripts/ui/turn-panel/index.js
@@ -1,0 +1,30 @@
+/**
+ * CosmereTurnPanel – replaces the stock PassTurnPanel with Cosmere-aware
+ * turn management buttons.
+ *
+ * When the cosmere-advanced-encounters module is active the panel delegates to
+ * the advanced button factory; otherwise it falls back to the basic factory.
+ */
+
+import { buildAdvancedButtons } from "./advanced.js";
+import { buildBasicButtons } from "./basic.js";
+
+const ADVANCED_ENCOUNTERS_ID = "cosmere-advanced-encounters";
+
+export class CosmereTurnPanel extends CONFIG.ARGON.PREFAB.PassTurnPanel {
+    get label() {
+        return "enhancedcombathud-cosmere-rpg.turn.panel";
+    }
+
+    get template() {
+        // Required due to template being by default computed from the immediate parent class name
+        return "modules/enhancedcombathud/templates/partials/ActionPanel.hbs";
+    }
+
+    async _getButtons() {
+        if (game.modules.get(ADVANCED_ENCOUNTERS_ID)?.active) {
+            return buildAdvancedButtons(this.actor);
+        }
+        return buildBasicButtons(this.actor);
+    }
+}

--- a/scripts/ui/turn-panel/toggle-speed-button.js
+++ b/scripts/ui/turn-panel/toggle-speed-button.js
@@ -1,0 +1,40 @@
+/**
+ * Shared turn-speed toggle button used by both the basic and advanced turn panels.
+ *
+ * Renders a CSS-variable-driven SVG icon (fast/slow) and calls
+ * combatant.toggleTurnSpeed() on click.  Hidden once the combatant has activated.
+ */
+export class ToggleTurnSpeedButton extends CONFIG.ARGON.MAIN.BUTTONS.ActionButton {
+    constructor(combatant) {
+        super();
+        this._combatant = combatant;
+    }
+
+    get label() {
+        return "COSMERE.Combat.ToggleTurn";
+    }
+
+    get colorScheme() { return 4; }
+
+    get visible() {
+        return !!game.combat?.started && !this._combatant.activated;
+    }
+
+    async _renderInner() {
+        await super._renderInner();
+         // Argon always add a background image, but ours is in CSS
+        this.element.style.backgroundImage = "";
+        this.element.classList.remove("toggle-turn-speed-button-fast", "toggle-turn-speed-button-slow");
+        this.element.classList.add(`toggle-turn-speed-button-${this._combatant.turnSpeed}`);
+    }
+
+    async _onLeftClick() {
+        // The hover icon show the opposite speed, so we don't want to show it after the click.
+        this.element.classList.add("suppress-hover");
+        this.element.addEventListener("mouseleave", () => {
+            this.element.classList.remove("suppress-hover");
+        }, { once: true });
+
+        await this._combatant.toggleTurnSpeed();
+    }
+}

--- a/styles/module.css
+++ b/styles/module.css
@@ -1,0 +1,16 @@
+
+:root .toggle-turn-speed-button-fast {
+  background-image: url("../../../systems/cosmere-rpg/assets/icons/svg/combat/icon_combat_fast_turn_on.svg");
+  background-position-x: 24px;
+}
+:root  .toggle-turn-speed-button-fast:hover:not(.suppress-hover) {
+  background-image: url("../../../systems/cosmere-rpg/assets/icons/svg/combat/icon_combat_fast_turn_hover.svg");
+}
+
+:root .toggle-turn-speed-button-slow {
+  background-image: url("../../../systems/cosmere-rpg/assets/icons/svg/combat/icon_combat_slow_turn_on.svg");
+  background-position-x: 24px;
+}
+:root .toggle-turn-speed-button-slow:hover:not(.suppress-hover) {
+  background-image: url("../../../systems/cosmere-rpg/assets/icons/svg/combat/icon_combat_slow_turn_hover.svg");
+}


### PR DESCRIPTION
**Type**

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**

Closes #8

This PR replaces PassTurnPanel with CosmereTurnPanel, a drop-in replacement that correctly models both the base Cosmere RPG combat flow and the extended flow provided by the [cosmere-advanced-encounters](https://github.com/boxfriend/enhancedcombathud-cosmere) module.

In addition, the Fast Turn/Slow Turn was moved into that panel, making it more visible, and reuse the icons of the Cosmere RPG System. Special care was taken so that the hover is also included, making it clear the impact of clicking on the button, and hiding the hover after the click to avoid confusions, fixing the new turn until the mouse moves out.

Without [cosmere-advanced-encounters](https://github.com/boxfriend/enhancedcombathud-cosmere):

- All combatants see an End Turn button whenever combat is started and they have not yet activated. Any player can end their turn freely regardless of who is "next" in the tracker.
- Boss actors instead see End Fast Turn and End Slow Turn, each independently tied to their respective activation flag (bossFastActivated) from the Cosmere RPG System.
- Non-boss combatants also see a Toggle Speed button (Fast ↔ Slow) that disappears once they have activated.

With [cosmere-advanced-encounters](https://github.com/boxfriend/enhancedcombathud-cosmere):

- Each combatant entry shows a Start Turn button, visible only when all combatants in earlier phases have activated and no one is currently mid-turn. Clicking it marks the combatant as activated and sets them as the current combatant.
- An End Turn button is visible only while that specific combatant is the active one. Clicking it clears the active combatant (returns to the between-turns state).
- Non-boss combatants also get the speed toggle, hidden for boss entries since AE controls their speed via separate entries.
- Boss actors have two separate combatant entries (Fast + Slow), one button group (Start and End Turn) each and don't have the Toggle Speed button

**Screenshots without Advanced Encounters**

Showcase :

<img width="1830" height="1032" alt="image" src="https://github.com/user-attachments/assets/26a4e540-e9be-4578-9777-7c99014e8065" />

Non-Boss, not activated:

<img width="221" height="157" alt="image" src="https://github.com/user-attachments/assets/5e59af58-f505-49fc-b6bb-e3b42da95b94" />

Hover support:

<img width="263" height="195" alt="image" src="https://github.com/user-attachments/assets/53bb9868-b018-4aa0-867a-42479449f6a9" />

Boss:

<img width="257" height="187" alt="image" src="https://github.com/user-attachments/assets/0c132c68-6796-454d-a758-93cd0bf68bd4" />

**Screenshots with Advanced Encounters**

Showcase:

<img width="1842" height="1047" alt="image" src="https://github.com/user-attachments/assets/325b51da-52c5-49bb-825d-b6ca6d8ac18a" />


PC in slow phase waiting for fast phase to be activated:

<img width="150" height="203" alt="image" src="https://github.com/user-attachments/assets/b8e9c994-0364-4300-8a07-61bc78e61b26" />

PC in slow phase when the fast phase is fully done:

<img width="300" height="205" alt="image" src="https://github.com/user-attachments/assets/7e006d18-9ef0-430b-908f-86027207ccd4" />

PC currently playing: 

<img width="175" height="200" alt="image" src="https://github.com/user-attachments/assets/273bbdf9-6098-4bac-b7bc-db5f1d40210e" />

Boss, when fast turn not fully activated:

<img width="163" height="196" alt="image" src="https://github.com/user-attachments/assets/0c3cbce5-0dae-4816-bbc3-cd2a322c6279" />


**How Has This Been Tested?**

- Created an encounter with PC, adversaries, and boss. 
- Tested all scenarios of turn order, with two users to test the GM and PC experience.
- Tested with or without Advanced Encounters

**Checklist:**

- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] I have tested my changes on Foundry VTT version 13, build 351.