### PR TITLE
fix(settings): sets default selected compendiums to none

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -75,6 +75,7 @@ export default function registerSettings() {
     game.settings.register(MODULE_ID, "selectedCompendiums", {
         config: false,
         scope: override ? "world" : "client",
+        default: []
     });
 
     game.settings.register(MODULE_ID, "showEmptyPanel", {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Just adds a default `[]` for the selectedCompendiums setting

**Related Issue**  
Closes #19 

**Checklist:**  
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes do not introduce any new warnings or errors.
- [x] My PR does not contain any copyrighted works that I do not have permission to use.
- [x] No part of this PR was created using generative AI tools.
- [x] I have tested my changes on Foundry VTT version: 13.351.


